### PR TITLE
Update FormAdd.js

### DIFF
--- a/resources/js/components/FormAdd.js
+++ b/resources/js/components/FormAdd.js
@@ -43,10 +43,12 @@ export default function FormAdd({ formAttributes }) {
 
   formAttributes.fieldData.map((field) => {
     if (field.hasOwnProperty('default')) {
-      setTriggeredValue({...triggeredValue,[field.identifier]: field.default});
+      let defaultValue = (eval(field.default) !== undefined ? eval(field.default) : field.default);
+      setTriggeredValue({...triggeredValue,[field.identifier]: defaultValue});
     }
     if (field.hasOwnProperty('defaultKey')) {
-      setTriggeredValue({...triggeredValue,[field.identifier+'_key']: field.default});
+      let defaultKey = (eval(field.defaultKey) !== undefined ? eval(field.defaultKey) : field.defaultKey)
+      setTriggeredValue({...triggeredValue,[field.identifier+'_key']: defaultKey});
     }
   });
 


### PR DESCRIPTION
To use the value of a variable as a default value. For example: 

whatever.yml:
  - identifier: term_code_ctlg
    label: Catalog Term
    type: autosuggest
    desc: "Enter a term code or description"
    attributes:
      required: required
    default: _catalog_term + ' - ' + _catalog_term_display
    defaultKey: _catalog_term
    values:
      url: %route:data.term.index%
      key: code
      display: desc
      search: code,desc
    view: 
      label: 2
      data: 10


WhateverController.php
...
$pass_vars = [
            ...
            '_catalog_term'=> $catalog_term->code,
            '_catalog_term_display'=> $catalog_term->desc,
            ...
        ];
...